### PR TITLE
solve ticket #14 and organize code

### DIFF
--- a/Block/Adminhtml/OrderAlert.php
+++ b/Block/Adminhtml/OrderAlert.php
@@ -17,13 +17,9 @@ class OrderAlert extends \Magento\Framework\View\Element\Template
         parent::__construct($context);
     }
 
-    public function getEnable()
+    public function isEnabled()
     {
-        if (!$this->dataHelper->moduleEnabled()) {
-            return '';
-        }
-
-        return true;
+        return $this->dataHelper->moduleEnabled();
     }
 
     public function getSoundFile()
@@ -36,9 +32,9 @@ class OrderAlert extends \Magento\Framework\View\Element\Template
         return $this->dataHelper->getSoundType();
     }
 
-    public function getDealy()
+    public function getDelay() :int
     {
-        return $this->dataHelper->getDealy();
+        return $this->dataHelper->getDelay();
     }
 
     public function getMediaUrl()

--- a/Controller/Adminhtml/Alert/Ordercreate.php
+++ b/Controller/Adminhtml/Alert/Ordercreate.php
@@ -6,19 +6,25 @@ use Magento\Backend\App\Action\Context;
 
 class Ordercreate extends Action
 {
-    protected $logger;
     protected $collectionFactory;
+    protected $orderCollectionFactory;
+    protected $orderNotificationFactory;
+    protected $authSession;
 
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
         \Yudiz\Ordernotification\Model\ResourceModel\Ordernotification\CollectionFactory $collectionFactory,
-        \Psr\Log\LoggerInterface $logger
+        \Yudiz\Ordernotification\Model\OrdernotificationFactory $orderNotificationFactory,
+        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
+        \Magento\Backend\Model\Auth\Session $authSession
     ) {
         parent::__construct($context);
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->logger = $logger;
         $this->collectionFactory = $collectionFactory;
+        $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->orderNotificationFactory = $orderNotificationFactory;
+        $this->authSession = $authSession;
     }
 
     /**
@@ -28,48 +34,35 @@ class Ordercreate extends Action
     {
 
         $data = [
-            'success' => 200,
-            'message' => __("Play sound"),
+            'success' => 413,
+            'message' => __("Already notified, Don't play sound"),
         ];
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $orderDatamodel = $objectManager->get(\Magento\Sales\Model\Order::class)->getCollection()->getLastItem();
-        $orderId = $orderDatamodel->getId();
+        $orderCollection = $this->orderCollectionFactory->create();
+        $orderCollection->getSelect()->order('entity_id DESC')->limit('1');
+        if($orderCollection->getSize()){
+            $orderDatamodel = $orderCollection->getFirstItem();
+            $orderId = $orderDatamodel->getId();
+            $userId = $this->authSession->getUser()->getId();
+            $isNotified = $this->collectionFactory->create()
+                ->addFieldToFilter('order_id', $orderId)
+                ->addFieldToFilter('user_id', $userId)
+                ->getSize();
 
-        $collection = $this->collectionFactory->create();
-        $orderNotificationFirstItem = $collection->getFirstItem();
-
-        $text = "";
-        $text = "New order " . $orderDatamodel->getIncrementId() . " placed by ";
-        $text .= $orderDatamodel->getCustomerFirstname() . " " . $orderDatamodel->getCustomerLastname();
-        $data['message'] = $text;
-
-        if ($orderNotificationFirstItem) {
-            if ($orderNotificationFirstItem->getOrderId() == $orderId) {
-                $data['success'] = 413;
-                $data['message'] = __("Not Play sound");
-            } else {
+            if (!$isNotified) {
                 if ($orderDatamodel->getStatus() == 'payment_review' || $orderDatamodel->getStatus() == 'pending_payment') {
                     $data['success'] = 413;
                     $data['message'] = __("Not Play sound, payment remain");
                 } else {
-                    $orderNotificationFirstItem->setOrderId($orderId);
-                    $orderNotificationFirstItem->setCreatedTime(date('Y-m-d H:i:s'));
-                    $orderNotificationFirstItem->save();
+                    $orderNotification = $this->orderNotificationFactory->create();
+                    $orderNotification->setOrderId($orderId)
+                        ->setUserId($userId)
+                        ->setCreatedTime(date('Y-m-d H:i:s'));
+                    $orderNotification->save();
                     $data['success'] = 200;
-                    $data['message'] = $text;
-
-                    // For log order data and order ID
-                    // $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/ordernotification.log');
-                    // $logger = new \Zend\Log\Logger();
-                    // $logger->addWriter($writer);
-                    // $logger->info(json_encode(["data" => $data, 'orderId' => $orderId]));
+                    $data['message'] = __("New order %1 place by %2", $orderDatamodel->getIncrementId(), $orderDatamodel->getCustomerFirstname() . " " . $orderDatamodel->getCustomerLastname());
                 }
-
             }
         }
-
-        //Send response to Ajax query
-        //$data = $orderId;
         $result = $this->resultJsonFactory->create();
         return $result->setData($data);
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Yudiz\Ordernotification\Helper;
 
 /**
@@ -9,37 +10,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Section name for configs
      */
-    const SECTION_ID = 'ordernotification';
-    const DEALY_TIME = 15000; // mili second: 15 seconds
+    const SECTION_ID = 'ordernotification/';
+    const DELAY_TIME = 15000; // millisecond: 15 seconds
 
-    protected $_configSectionId = 'ordernotification';
 
-    /**
-     * Core registry
-     *
-     * @var \Magento\Framework\Registry
-     */
-    protected $_coreRegistry;
-
-    /**
-     * @param Context $context
-     * @param array $data
-     */
-    public function __construct(
-        \Magento\Framework\App\Helper\Context $context,
-        \Magento\Framework\Registry $registry
-    ) {
-        $this->_scopeConfig = $context->getScopeConfig();
-        $this->_configSectionId = self::SECTION_ID;
-        $this->_coreRegistry = $registry;
-        parent::__construct($context);
-    }
-
-    public function getConfig($configPath)
+    public function getConfig($configPath, $storeId = null)
     {
         return $this->scopeConfig->getValue(
-            $configPath,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            self::SECTION_ID . $configPath,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            $storeId
         );
     }
 
@@ -48,25 +28,21 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function moduleEnabled(): bool
     {
-        return (bool) $this->getConfig($this->_configSectionId . '/general/enable');
+        return (bool)$this->getConfig('general/enable');
     }
 
     public function getAudioFile()
     {
-
-        return $this->getConfig($this->_configSectionId . '/general/audio_file_upload');
+        return $this->getConfig('general/audio_file_upload');
     }
 
     public function getSoundType()
     {
-
-        return $this->getConfig($this->_configSectionId . '/general/audio_type');
+        return $this->getConfig('general/audio_type');
     }
 
-    public function getDealy()
+    public function getDelay(): int
     {
-
-        return self::DEALY_TIME;
-        //return $this->getConfig($this->_configSectionId . '/general/audio_file_upload');
+        return (int) $this->getConfig('general/delay_time') ?? self::DELAY_TIME;
     }
 }

--- a/Model/ResourceModel/Ordernotification/Collection.php
+++ b/Model/ResourceModel/Ordernotification/Collection.php
@@ -1,9 +1,8 @@
 <?php
 namespace Yudiz\Ordernotification\Model\ResourceModel\Ordernotification;
 
-use Yudiz\Ordernotification\Model\ResourceModel\AbstractCollection;
 
-class Collection extends AbstractCollection
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
 {
     protected $_idFieldName = 'ordernotification_id';
 

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * UpgradeSchema
+ *
+ * @copyright Copyright © 2023 Ushop Unilever. All rights reserved.
+ * @author    ahmed.allam@unilever.com
+ */
+
+namespace Yudiz\Ordernotification\Setup;
+
+
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\DB\Ddl\Table;
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+
+        $setup->startSetup();
+        if (version_compare($context->getVersion(), '1.3.0', '<'))
+        {
+            $setup->getConnection()->addColumn(
+                $setup->getTable('yudiz_ordernotification'),
+                'user_id',
+                [
+                    'type' => Table::TYPE_TEXT,
+                    'length' => 255,
+                    'nullable' => false,
+                    'comment' => 'Notified user id'
+                ]
+            );
+        }
+
+        $setup->endSetup();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
-    <system>        
-        <tab id="newordernotification" translate="label" sortOrder="2001"><label>Order Notification</label></tab> 
+    <system>
+        <tab id="newordernotification" translate="label" sortOrder="2001"><label>Order Notification</label></tab>
         <section id="ordernotification" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
             <label>Settings</label>
@@ -13,17 +13,22 @@
                     <label>Module Enable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="audio_type" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="delay_time" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Delay Time</label>
+                    <comment>Time in milli second (1 second = 1000 Milliseconds)</comment>
+                    <validate>validate-number</validate>
+                </field>
+                <field id="audio_type" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Sound Type</label>
                     <source_model>Yudiz\Ordernotification\Model\Config\Source\Soundtype</source_model>
                     <comment>Please select you want to play speech or play sound only.</comment>
                 </field>
-                <field id="audio_file_upload" translate="label" type="Magento\Config\Block\System\Config\Form\Field\File" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0" >
+                <field id="audio_file_upload" translate="label" type="Magento\Config\Block\System\Config\Form\Field\File" sortOrder="4" showInDefault="1" showInWebsite="0" showInStore="0" >
                     <label>Upload soud file</label>
                     <backend_model>Yudiz\Ordernotification\Model\Config\Backend\File\CustomFileType</backend_model>
                     <upload_dir config="system/sound" scope_info="1">order_sound</upload_dir>
                     <comment><![CDATA[Allowed file types: 'mp3', 'mp4', 'wav', 'wma', 'aac']]></comment>
-                </field>            
+                </field>
             </group>
         </section>
     </system>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yudiz_Ordernotification" setup_version="1.2.0">
+    <module name="Yudiz_Ordernotification" setup_version="1.3.0">
         <sequence>
             <module name="Magento_Store"/>
         </sequence>

--- a/view/adminhtml/templates/order/alert/message.phtml
+++ b/view/adminhtml/templates/order/alert/message.phtml
@@ -1,13 +1,13 @@
 <?php
 /** @var \Yudiz\Ordernotification\Block\Adminhtml\OrderAlert $block */
-$enable = $block->getEnable();
+$isEnabled = $block->isEnabled();
 ?>
-<?php if ($enable): ?>
+<?php if ($isEnabled): ?>
     <?php
-    
+
     $audio_file = $block->getSoundFile();
     $mediaUrl = $block->getMediaUrl();
-    $dealy_time = $block->getDealy();
+    $delay_time = $block->getDelay();
     $sound_type = $block->getSoundType();
 
     if (!$sound_type) {
@@ -21,7 +21,7 @@ $enable = $block->getEnable();
     } else {
         $sound = $mediaUrl.$audio_file;
     }
-    
+
     ?>
     <audio id="playOrderAudio">
         <source src="<?= $block->escapeHtml($sound); ?>" type="audio/mpeg">
@@ -33,14 +33,14 @@ $enable = $block->getEnable();
             'jquery',
             'jquery/ui'
         ], function ($) {
-            var dealy_time = "<?= $block->escapeHtml($dealy_time); ?>";
-            var sound_play = "<?= $block->escapeHtml($sound_play); ?>";
+            var delay_time = <?= $block->escapeHtml($delay_time); ?>,
+                sound_play = "<?= $block->escapeHtml($sound_play); ?>";
             $(document).ready(function(){
                 checkNewOrder();
             });
 
             function checkNewOrder(){
-                var ajaxRequest;
+                let ajaxRequest;
                 ajaxRequest = $.ajax({
                     url: "<?= $block->escapeUrl($block->getUrl('ordernotification/alert/ordercreate')); ?>",
                     type: 'GET',
@@ -63,7 +63,7 @@ $enable = $block->getEnable();
                         }else{
                             playAudio();
                         }
-                        
+
                     }
                 });
                 //On failure of request this function will be called
@@ -73,16 +73,16 @@ $enable = $block->getEnable();
                     // $('#loader').hide();
                 });
 
-                setTimeout(function(){ checkNewOrder() }, dealy_time);
+                setTimeout(function(){ checkNewOrder() }, delay_time);
             }
 
             function playAudio() {
-                var x = document.getElementById("playOrderAudio"); 
+                var x = document.getElementById("playOrderAudio");
                 document.getElementById('playOrderAudio').muted = false;
                 document.getElementById("playOrderAudio").play();
             }
             function playSpeech(speech_text = '') {
-                
+
                 let speech = new SpeechSynthesisUtterance();
                     speech.lang = "en";
 
@@ -98,8 +98,7 @@ $enable = $block->getEnable();
                     speech.voice = voices[33];
                 speech.text = speech_text;
                 window.speechSynthesis.speak(speech);
-                console.log(speech);
-            } 
+            }
         });
     </script>
 <?php endif; ?>


### PR DESCRIPTION
using getLastItem() on collection may cause CPU high usage
check this https://alanastorm.com/magentos-getlastitem-method-considered-harmful/
the updated code used limit('1') to solve this issue.
- New Feature
-- Added multi user notification support ( The old code was adding only order id to the notification table causes the 1st admin user  to receive the notification only, but if you have more than 1 admin user account, the others won't be notified).
-- Added Delay time to stores configurations, so you can control it from the backend